### PR TITLE
Implemented NIL UUID as default namespace with legacy option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,9 +6,10 @@
  * @param {3|5} [version=3] Version of UUID. Available versions is 3 and 5
  * according to RFC-4122. The version is responsible for the hashing algorithm:
  * version 3 uses MD5, and version 5 uses SHA-1.
+ * @param {boolean} [legacyMethod]
  * @returns {string} UUID
  */
-declare function getUuidByString(target: string, namespace?: string, version?: 3 | 5): string
+declare function getUuidByString(target: string, namespace?: string, version?: 3 | 5, legacyMethod?: boolean): string
 declare function getUuidByString(target: string, version?: 3 | 5): string
 
 // prettier-ignore

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,9 @@ var lib = require('./lib');
 /** Uin8Array with zero items */
 var EMPTY_UINT8_ARRAY = new Uint8Array(0);
 
+/** Uin8Array with 16 zeros (represents the nil UUID) */
+var NIL_UUID_UINT8_ARRAY = new Uint8Array(16);
+
 /**
  * Generates the Name-Based UUID hashes v3 and v5 according to RFC-4122
  * https://tools.ietf.org/html/rfc4122#section-4.3
@@ -11,19 +14,20 @@ var EMPTY_UINT8_ARRAY = new Uint8Array(0);
  * @param {3|5} [version=5] Version of UUID. Available versions is 3 and 5
  * according to RFC-4122. The version is responsible for the hashing algorithm:
  * version 3 uses MD5, and version 5 uses SHA-1. Default is 5.
+ * @param {boolean} [legacyMethod]
  * @returns {string} UUID
  */
-function generateUuid(target, namespace, version) {
+function generateUuid(target, namespace, version, legacyMethod) {
   if (typeof target !== 'string') {
     throw TypeError('Value must be string');
   }
 
   if (typeof namespace === 'number') {
-    return generateUuid(target, undefined, namespace);
+    return generateUuid(target, undefined, namespace, legacyMethod);
   }
 
   if (version == null) {
-    return generateUuid(target, namespace, 5);
+    return generateUuid(target, namespace, 5, legacyMethod);
   }
 
   if (version !== 3 && version !== 5) {
@@ -32,7 +36,12 @@ function generateUuid(target, namespace, version) {
 
   // Parsing target chars
   var targetCharBuffer = lib.stringToCharBuffer(target);
-  var namespaceCharBuffer = typeof namespace === 'string' ? lib.parseUuid(namespace) : EMPTY_UINT8_ARRAY;
+  var namespaceCharBuffer = 
+    typeof namespace === 'string'
+    ? lib.parseUuid(namespace)
+    : (
+      legacyMethod ? EMPTY_UINT8_ARRAY : NIL_UUID_UINT8_ARRAY
+    );
 
   // Concatenation two buffers of strings to one
   var buffer = lib.concatBuffers(namespaceCharBuffer, targetCharBuffer);

--- a/tests/__snapshots__/test.js.snap
+++ b/tests/__snapshots__/test.js.snap
@@ -1,14 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`integration should generate uuid v3 from string 1`] = `"d41d8cd9-8f00-3204-a980-0998ecf8427e"`;
+exports[`integration should generate uuid v3 from string - legacy 1`] = `"d41d8cd9-8f00-3204-a980-0998ecf8427e"`;
 
-exports[`integration should generate uuid v3 from string 2`] = `"86fb269d-190d-3c85-b6e0-468ceca42a20"`;
+exports[`integration should generate uuid v3 from string - legacy 2`] = `"86fb269d-190d-3c85-b6e0-468ceca42a20"`;
 
-exports[`integration should generate uuid v3 from string 3`] = `"0956d2fb-d5d5-3298-84a4-d21ed2f76e0c"`;
+exports[`integration should generate uuid v3 from string - legacy 3`] = `"0956d2fb-d5d5-3298-84a4-d21ed2f76e0c"`;
 
-exports[`integration should generate uuid v3 from string 4`] = `"20b085c2-2e91-324f-89c2-648fc03ee626"`;
+exports[`integration should generate uuid v3 from string - legacy 4`] = `"20b085c2-2e91-324f-89c2-648fc03ee626"`;
 
-exports[`integration should generate uuid v3 from string 5`] = `"34e58612-20fa-3978-bbe1-656b34ab2f2f"`;
+exports[`integration should generate uuid v3 from string - legacy 5`] = `"34e58612-20fa-3978-bbe1-656b34ab2f2f"`;
+
+exports[`integration should generate uuid v3 from string 1`] = `"4ae71336-e44b-39bf-b9d2-752e234818a5"`;
+
+exports[`integration should generate uuid v3 from string 2`] = `"f7c44786-7e81-386b-a7a5-95ef58bcb389"`;
+
+exports[`integration should generate uuid v3 from string 3`] = `"7e7c264e-35a5-3e17-97c9-6467e3b4359c"`;
+
+exports[`integration should generate uuid v3 from string 4`] = `"8c085e86-f500-3556-b08e-3fe16c7d7724"`;
+
+exports[`integration should generate uuid v3 from string 5`] = `"0d12c6ed-bc6d-356f-8932-ee6ab1262870"`;
 
 exports[`integration should generate uuid v3 from string with namespace 1`] = `"6d72c664-05f7-5ae7-8653-ee9ebed25b00"`;
 
@@ -20,15 +30,25 @@ exports[`integration should generate uuid v3 from string with namespace 4`] = `"
 
 exports[`integration should generate uuid v3 from string with namespace 5`] = `"5daf5b6d-b5e8-5e22-96c4-71e0fd8c4540"`;
 
-exports[`integration should generate uuid v5 from string 1`] = `"da39a3ee-5e6b-5b0d-b255-bfef95601890"`;
+exports[`integration should generate uuid v5 from string - legacy 1`] = `"da39a3ee-5e6b-5b0d-b255-bfef95601890"`;
 
-exports[`integration should generate uuid v5 from string 2`] = `"d3486ae9-136e-5856-bc42-212385ea7970"`;
+exports[`integration should generate uuid v5 from string - legacy 2`] = `"d3486ae9-136e-5856-bc42-212385ea7970"`;
 
-exports[`integration should generate uuid v5 from string 3`] = `"94912be8-b3fb-57d4-961e-a50e5948c629"`;
+exports[`integration should generate uuid v5 from string - legacy 3`] = `"94912be8-b3fb-57d4-961e-a50e5948c629"`;
 
-exports[`integration should generate uuid v5 from string 4`] = `"ae49974d-2750-5eb2-b004-24bf83a04950"`;
+exports[`integration should generate uuid v5 from string - legacy 4`] = `"ae49974d-2750-5eb2-b004-24bf83a04950"`;
 
-exports[`integration should generate uuid v5 from string 5`] = `"c81386c7-744f-5af9-8899-cfdd14664aa7"`;
+exports[`integration should generate uuid v5 from string - legacy 5`] = `"c81386c7-744f-5af9-8899-cfdd14664aa7"`;
+
+exports[`integration should generate uuid v5 from string 1`] = `"e129f27c-5103-5c5c-844b-cdf0a15e160d"`;
+
+exports[`integration should generate uuid v5 from string 2`] = `"ec74fa6c-5be6-5388-8cb3-d91001210130"`;
+
+exports[`integration should generate uuid v5 from string 3`] = `"e09defe7-e8dd-5995-a741-57669517728a"`;
+
+exports[`integration should generate uuid v5 from string 4`] = `"583709b5-7c35-5f81-8a64-136786bda678"`;
+
+exports[`integration should generate uuid v5 from string 5`] = `"57cccf14-e652-5428-8013-4380d74a86e6"`;
 
 exports[`integration should generate uuid v5 from string with namespace 1`] = `"6d72c664-05f7-5ae7-8653-ee9ebed25b00"`;
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -11,6 +11,8 @@ const {
 } = require('../src/lib');
 const { longText } = require('./__mock__/longText');
 
+const NIL_UUID = '00000000-0000-0000-0000-000000000000'
+
 const stringSamples = [
   '',
   'Hello world!',
@@ -93,7 +95,11 @@ describe('unit', () => {
 
 describe('integration', () => {
   test('Hello world!', () => {
-    expect(generateUuid('Hello world!')).toBe('d3486ae9-136e-5856-bc42-212385ea7970');
+    expect(generateUuid('Hello world!')).toBe('ec74fa6c-5be6-5388-8cb3-d91001210130');
+  });
+
+  test('Hello world! - legacy', () => {
+    expect(generateUuid('Hello world!', undefined, undefined, true)).toBe('d3486ae9-136e-5856-bc42-212385ea7970');
   });
 
   test('should throw error because of the wrong value', () => {
@@ -108,6 +114,14 @@ describe('integration', () => {
   test('should generate uuid v3 from string', () => {
     for (let i = 0; i < stringSamples.length; i++) {
       const uuid = generateUuid(stringSamples[i], 3);
+
+      expect(uuid).toMatchSnapshot();
+    }
+  });
+
+  test('should generate uuid v3 from string - legacy', () => {
+    for (let i = 0; i < stringSamples.length; i++) {
+      const uuid = generateUuid(stringSamples[i], undefined, 3, true);
 
       expect(uuid).toMatchSnapshot();
     }
@@ -129,6 +143,14 @@ describe('integration', () => {
     }
   });
 
+  test('should generate uuid v5 from string - legacy', () => {
+    for (let i = 0; i < stringSamples.length; i++) {
+      const uuid = generateUuid(stringSamples[i], undefined, undefined, true);
+
+      expect(uuid).toMatchSnapshot();
+    }
+  });
+
   test('should generate uuid v5 from string with namespace', () => {
     for (let i = 0; i < stringSamples.length; i++) {
       const uuid = generateUuid(stringSamples[i], 'd3486ae9-136e-5856-bc42-212385ea7970', 5);
@@ -138,7 +160,11 @@ describe('integration', () => {
   });
 
   test('should generate platform compatible uuid', () => {
-    expect(generateUuid('9239107d-259f-4cf8-b62d-0964b680ab08', 3)).toBe('12f01aa4-5090-3f83-b823-7e7cb43246e7');
+    expect(generateUuid('9239107d-259f-4cf8-b62d-0964b680ab08', 3)).toBe('027cee5f-02c5-313a-8acd-62f33637e544');
+  });
+
+  test('should generate platform compatible uuid - legacy', () => {
+    expect(generateUuid('9239107d-259f-4cf8-b62d-0964b680ab08', undefined, 3, true)).toBe('12f01aa4-5090-3f83-b823-7e7cb43246e7');
   });
 });
 
@@ -147,3 +173,25 @@ describe('checker of speed of one generation', () => {
     generateUuid(longText);
   });
 });
+
+describe('tests for the nil UUID namespace', () => {
+  test('v3', () => {
+    for (let i = 0; i < stringSamples.length; i++) {
+      expect(
+        generateUuid(stringSamples[i], NIL_UUID, 3)
+      ).toBe(
+        generateUuid(stringSamples[i], 3)
+      );
+    }
+  });
+
+  test('v5', () => {
+    for (let i = 0; i < stringSamples.length; i++) {
+      expect(
+        generateUuid(stringSamples[i], NIL_UUID, 5)
+      ).toBe(
+        generateUuid(stringSamples[i], 5)
+      );
+    }
+  });
+})


### PR DESCRIPTION
Motivation: make the generator compatible with the specification (with default namespace of nil UUID) and provide the legacy option for these who rely on the old (non-standard) implementation.