### PR TITLE
Replace crypto dependencies with node internals

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,10 +39,6 @@
       "src/**"
     ]
   },
-  "dependencies": {
-    "js-md5": "^0.7.3",
-    "js-sha1": "^0.6.0"
-  },
   "devDependencies": {
     "eslint": "^8.23.0",
     "jest": "^27.0.1"

--- a/src/lib.js
+++ b/src/lib.js
@@ -1,5 +1,4 @@
-var md5 = require('js-md5');
-var sha1 = require('js-sha1');
+var crypto = require('node:crypto');
 
 /** List of hex digit for fast accessing by index */
 var HEX_DIGITS = '0123456789abcdef'.split('');
@@ -72,7 +71,7 @@ var stringToCharBuffer = function (str) {
  * @returns {Uint8Array} MD5 hash buffer
  */
 var md5Hash = function (buf) {
-  return new Uint8Array(md5.arrayBuffer(buf));
+  return new Uint8Array(crypto.createHash('md5').update(buf).digest());
 };
 
 /**
@@ -81,7 +80,7 @@ var md5Hash = function (buf) {
  * @returns {Uint8Array} SHA-1 hash buffer
  */
 var sha1Hash = function (buf) {
-  return new Uint8Array(sha1.arrayBuffer(buf));
+  return new Uint8Array(crypto.createHash('sha1').update(buf).digest());
 };
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2063,16 +2063,6 @@ jest@^27.0.1:
     import-local "^3.0.2"
     jest-cli "^27.5.1"
 
-js-md5@^0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/js-md5/-/js-md5-0.7.3.tgz#b4f2fbb0b327455f598d6727e38ec272cd09c3f2"
-  integrity sha512-ZC41vPSTLKGwIRjqDh8DfXoCrdQIyBgspJVPXHBGu4nZlAEvG3nf+jO9avM9RmLiGakg7vz974ms99nEV0tmTQ==
-
-js-sha1@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/js-sha1/-/js-sha1-0.6.0.tgz#adbee10f0e8e18aa07cdea807cf08e9183dbc7f9"
-  integrity sha512-01gwBFreYydzmU9BmZxpVk6svJJHrVxEN3IOiGl6VO93bVKYETJ0sIth6DASI6mIFdt7NmfX9UiByRzsYHGU9w==
-
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
Nodejs's crypto has functions to generate md5 and sha1 hashes so external dependencies aren't needed. This is particularly interesting in this case because the removal of such dependencies would mean that this library is dependency-free.

Discussion in https://github.com/danakt/uuid-by-string/issues/24